### PR TITLE
fix ChatBubble style at system using light color theme

### DIFF
--- a/components/ChatBox.vue
+++ b/components/ChatBox.vue
@@ -82,7 +82,7 @@ watch(
         </button>
       </header>
       <!-- Messages -->
-      <div class="messages p-4 overflow-y-scroll max-h-[80vh]" ref="messageBox">
+      <div class="messages p-4 overflow-y-auto max-h-[80vh]" ref="messageBox">
         <div v-if="!messages.length" class="text-center w-[350px] m-auto">
           <strong class="text-lg">Chat with Botman!</strong>
           <p>Our A.I. powered assistant</p>

--- a/components/ChatBubble.vue
+++ b/components/ChatBubble.vue
@@ -29,8 +29,9 @@ defineProps<{
     </div>
     <div
       data-test="chat-bubble-text"
-      class="chat-bubble py-0 prose prose-sm bg-white dark:bg-gray-900 max-w-max w-full"
+      class="chat-bubble py-0 prose prose-sm dark:bg-gray-900 max-w-max w-full"
       :class="{
+        'bg-white': !myMessage,
         'dark:bg-gray-700 bg-gray-600 dark:text-inherit text-white': myMessage,
       }"
     >


### PR DESCRIPTION
1. Modify the Message block overflow-y from scroll to auto to avoid the scroll bar to appear all the time.
2. Fixed ChatBubble in light color theme, the text color and background color of myMessage are white.

Before:
![before](https://i.imgur.com/PczBli0.png)

Fixed:
![Fixed](https://i.imgur.com/LP481EV.png)